### PR TITLE
Performance Improvement

### DIFF
--- a/Draftsman/Classes/Model/PlanDelegate.swift
+++ b/Draftsman/Classes/Model/PlanDelegate.swift
@@ -15,7 +15,7 @@ public protocol PlanDelegate: AnyObject {
     func planer(_ view: UIView, errorWhenPlanning error: DraftsmanError)
 }
 
-public final class DefaultPlanDelegate: PlanDelegate {
+final class DefaultPlanDelegate: PlanDelegate {
     static var shared: PlanDelegate = DefaultPlanDelegate()
 }
 

--- a/Draftsman/Classes/Plan/LayoutConstraintBuilder.swift
+++ b/Draftsman/Classes/Plan/LayoutConstraintBuilder.swift
@@ -17,8 +17,8 @@ public protocol LayoutConstraintBuilder {
 
 public extension LayoutConstraintBuilder {
     func identifierPrefix(for context: PlanContext) -> String {
-        if let viewPlanId = context.viewPlanId {
-            return "draftsman_viewplanid_\(viewPlanId)"
+        if context.usingViewPlan {
+            return "draftsman_viewplanid_\(context.rootContextView.uniqueKey)"
         } else {
             return "draftsman"
         }

--- a/Draftsman/Classes/Plan/LayoutConstraintBuilder.swift
+++ b/Draftsman/Classes/Plan/LayoutConstraintBuilder.swift
@@ -11,11 +11,11 @@ import UIKit
 
 // MARK: LayoutConstraintBuilder
 
-public protocol LayoutConstraintBuilder {
+protocol LayoutConstraintBuilder {
     func build(for context: PlanContext) -> NSLayoutConstraint?
 }
 
-public extension LayoutConstraintBuilder {
+extension LayoutConstraintBuilder {
     func identifierPrefix(for context: PlanContext) -> String {
         if context.usingViewPlan {
             return "draftsman_viewplanid_\(context.rootContextView.uniqueKey)"

--- a/Draftsman/Classes/Plan/LayoutScheme.swift
+++ b/Draftsman/Classes/Plan/LayoutScheme.swift
@@ -100,6 +100,9 @@ public class LayoutScheme<View: UIView>: RootViewPlan, ViewScheme {
 
 public extension LayoutScheme where View: UIStackView {
     func insertStacked(@LayoutPlan _ layouter: () -> ViewPlan) -> Self {
+        if viewInScheme is Planned, context.usingViewPlan, context.rootContextView == viewInScheme {
+            fatalError("Draftsman Error: Planned view or view controller should be managed its own content")
+        }
         subPlanAccessed = true
         self.subPlan.append(
             contentsOf:

--- a/Draftsman/Classes/Plan/LayoutScheme.swift
+++ b/Draftsman/Classes/Plan/LayoutScheme.swift
@@ -10,30 +10,6 @@ import Foundation
 import UIKit
 import Builder
 
-// MARK: ViewScheme
-
-public protocol ViewScheme: ViewPlan {
-    var isStackContent: Bool { get set }
-    var view: UIView { get }
-    var constraintBuilders: [LayoutConstraintBuilder] { get set }
-    func insert(@LayoutPlan _ layouter: () -> ViewPlan) -> Self
-    func build() -> [NSLayoutConstraint]
-    @discardableResult
-    func apply() -> [NSLayoutConstraint]
-}
-
-public extension ViewScheme {
-    
-    func build() -> [NSLayoutConstraint] {
-        build(for: view)
-    }
-    
-    @discardableResult
-    func apply() -> [NSLayoutConstraint] {
-        apply(for: view)
-    }
-}
-
 // MARK: LayoutScheme
 
 public class LayoutScheme<View: UIView>: RootViewPlan, ViewScheme {

--- a/Draftsman/Classes/Plan/PlanComponent.swift
+++ b/Draftsman/Classes/Plan/PlanComponent.swift
@@ -11,8 +11,11 @@ import UIKit
 
 public protocol PlanComponent: AnyObject { }
 
-public protocol ViewPlan: PlanComponent {
+protocol ViewPlaning: ViewPlan {
     var context: PlanContext { get set }
+}
+
+public protocol ViewPlan: PlanComponent {
     var subPlan: [ViewScheme] { get }
     @discardableResult
     func build(for view: UIView) -> [NSLayoutConstraint]
@@ -29,7 +32,7 @@ final class VoidView: UIView {
     }
 }
 
-final class VoidViewPlan: ViewPlan {
+final class VoidViewPlan: ViewPlaning {
     lazy var context: PlanContext = .default
     
     var subPlan: [ViewScheme] = []

--- a/Draftsman/Classes/Plan/PlanComponent.swift
+++ b/Draftsman/Classes/Plan/PlanComponent.swift
@@ -20,10 +20,22 @@ public protocol ViewPlan: PlanComponent {
     func apply(for view: UIView) -> [NSLayoutConstraint]
 }
 
+final class VoidView: UIView {
+    
+    override func addSubview(_ view: UIView) { }
+    
+    override func didMoveToSuperview() {
+        removeFromSuperview()
+    }
+}
+
 final class VoidViewPlan: ViewPlan {
-    var context: PlanContext = PlanContext(currentView: UIView())
+    lazy var context: PlanContext = .default
+    
     var subPlan: [ViewScheme] = []
+    
     func build(for view: UIView) -> [NSLayoutConstraint] { [] }
+    
     @discardableResult
     func apply(for view: UIView) -> [NSLayoutConstraint] { [] }
 }

--- a/Draftsman/Classes/Plan/PlanContext.swift
+++ b/Draftsman/Classes/Plan/PlanContext.swift
@@ -9,7 +9,7 @@ import Foundation
 #if canImport(UIKit)
 import UIKit
 
-public final class PlanContext {
+final class PlanContext {
     weak var _delegate: PlanDelegate?
     var delegate: PlanDelegate {
         _delegate ?? DefaultPlanDelegate.shared
@@ -42,7 +42,7 @@ public final class PlanContext {
     }
 }
 
-public extension PlanContext {
+extension PlanContext {
     static var `default`: PlanContext { PlanContext(delegate: nil, rootContextView: VoidView(), usingViewPlan: false) }
 }
 #endif

--- a/Draftsman/Classes/Plan/PlanContext.swift
+++ b/Draftsman/Classes/Plan/PlanContext.swift
@@ -23,21 +23,26 @@ public final class PlanContext {
     var currentView: UIView {
         didSet {
             guard currentView != oldValue else { return }
-            previousView = oldValue
+            let usedToBeVoid = oldValue is VoidView
+            previousView = usedToBeVoid ? nil : oldValue
+            rootContextView = usedToBeVoid ? rootContextView : currentView
         }
     }
-    var inViewPlan: Bool {
-        guard let planId: String = viewPlanId else { return false }
-        return !planId.isEmpty
-    }
+    let usingViewPlan: Bool
     var rootContextController: UIViewController?
-    var viewPlanId: String?
+    var rootContextView: UIView
     var previousView: UIView?
+    var applying: Bool = false
     
-    init(delegate: PlanDelegate? = nil, currentView: UIView, viewPlanId: String? = nil) {
-        self.viewPlanId = viewPlanId
+    init(delegate: PlanDelegate? = nil, rootContextView: UIView, usingViewPlan: Bool) {
         self._delegate = delegate
-        self.currentView = currentView
+        self.rootContextView = rootContextView
+        self.currentView = rootContextView
+        self.usingViewPlan = usingViewPlan
     }
+}
+
+public extension PlanContext {
+    static var `default`: PlanContext { PlanContext(delegate: nil, rootContextView: VoidView(), usingViewPlan: false) }
 }
 #endif

--- a/Draftsman/Classes/Plan/PlanConvertible.swift
+++ b/Draftsman/Classes/Plan/PlanConvertible.swift
@@ -46,7 +46,7 @@ public extension PlanConvertible where Self: UIView {
         }
         let viewPlan = layouter()
         let rootPlan = viewPlan as? RootViewPlan ?? RootViewPlan(subPlan: viewPlan.subPlan)
-        rootPlan.delegate = delegate
+        rootPlan.context = PlanContext(delegate: delegate, rootContextView: self, usingViewPlan: false)
         return rootPlan.apply(for: self)
     }
 }
@@ -70,7 +70,7 @@ public extension PlanConvertible where Self: UIStackView {
                 return $0
             }
         )
-        rootPlan.delegate = delegate
+        rootPlan.context = PlanContext(delegate: delegate, rootContextView: self, usingViewPlan: false)
         return rootPlan.apply(for: self)
     }
 }

--- a/Draftsman/Classes/Plan/PlanConvertible.swift
+++ b/Draftsman/Classes/Plan/PlanConvertible.swift
@@ -29,10 +29,10 @@ public extension PlanConvertible where Self: UIView {
     
     var plan: LayoutScheme<Self> {
         if let planned = self as? Planned {
-            if planned.selfPlanned {
-                return PlannedLayoutScheme(view: self)
-            } else {
+            if planned.needPlanning {
                 return PlannedLayoutScheme(view: self, subPlan: planned.viewPlan.subPlan)
+            } else {
+                return PlannedLayoutScheme(view: self)
             }
         }
         return LayoutScheme(view: self)
@@ -70,7 +70,7 @@ public extension PlanConvertible where Self: UIStackView {
         let viewPlan = layouter()
         let rootPlan = RootViewPlan(
             subPlan: viewPlan.subPlan.compactMap {
-                $0.isStackContent = true
+                ($0 as? ViewScheming)?.isStackContent = true
                 return $0
             }
         )
@@ -83,10 +83,10 @@ public extension PlanConvertible where Self: UIViewController {
     
     var plan: LayoutScheme<UIView> {
         if let planned = self as? Planned {
-            if planned.selfPlanned {
-                return PlannedLayoutScheme(view: self.view)
-            } else {
+            if planned.needPlanning {
                 return PlannedLayoutScheme(view: self.view, subPlan: planned.viewPlan.subPlan)
+            } else {
+                return PlannedLayoutScheme(view: self.view)
             }
         }
         return LayoutScheme(view: self.view)

--- a/Draftsman/Classes/Plan/PlanConvertible.swift
+++ b/Draftsman/Classes/Plan/PlanConvertible.swift
@@ -28,10 +28,14 @@ extension UIViewController: PlanConvertible {
 public extension PlanConvertible where Self: UIView {
     
     var plan: LayoutScheme<Self> {
-        guard let planned = self as? Planned, !planned.selfPlanned else {
-            return LayoutScheme(view: self)
+        if let planned = self as? Planned {
+            if planned.selfPlanned {
+                return PlannedLayoutScheme(view: self)
+            } else {
+                return PlannedLayoutScheme(view: self, subPlan: planned.viewPlan.subPlan)
+            }
         }
-        return LayoutScheme(view: self, subPlan: planned.viewPlan.subPlan, originalViewPlanId:  self.uniqueKey)
+        return LayoutScheme(view: self)
     }
     
     @discardableResult
@@ -78,10 +82,14 @@ public extension PlanConvertible where Self: UIStackView {
 public extension PlanConvertible where Self: UIViewController {
     
     var plan: LayoutScheme<UIView> {
-        guard let planned = self as? Planned, !planned.selfPlanned else {
-            return LayoutScheme(view: view)
+        if let planned = self as? Planned {
+            if planned.selfPlanned {
+                return PlannedLayoutScheme(view: self.view)
+            } else {
+                return PlannedLayoutScheme(view: self.view, subPlan: planned.viewPlan.subPlan)
+            }
         }
-        return LayoutScheme(view: self.view, subPlan: planned.viewPlan.subPlan, originalViewPlanId:  self.uniqueKey)
+        return LayoutScheme(view: self.view)
     }
     
     @discardableResult

--- a/Draftsman/Classes/Plan/PlanConvertible.swift
+++ b/Draftsman/Classes/Plan/PlanConvertible.swift
@@ -28,7 +28,7 @@ extension UIViewController: PlanConvertible {
 public extension PlanConvertible where Self: UIView {
     
     var plan: LayoutScheme<Self> {
-        guard let planned = self as? Planned else {
+        guard let planned = self as? Planned, !planned.selfPlanned else {
             return LayoutScheme(view: self)
         }
         return LayoutScheme(view: self, subPlan: planned.viewPlan.subPlan, originalViewPlanId:  self.uniqueKey)
@@ -78,7 +78,7 @@ public extension PlanConvertible where Self: UIStackView {
 public extension PlanConvertible where Self: UIViewController {
     
     var plan: LayoutScheme<UIView> {
-        guard let planned = self as? Planned else {
+        guard let planned = self as? Planned, !planned.selfPlanned else {
             return LayoutScheme(view: view)
         }
         return LayoutScheme(view: self.view, subPlan: planned.viewPlan.subPlan, originalViewPlanId:  self.uniqueKey)

--- a/Draftsman/Classes/Plan/PlannedLayoutScheme.swift
+++ b/Draftsman/Classes/Plan/PlannedLayoutScheme.swift
@@ -1,0 +1,30 @@
+//
+//  PlannedLayoutScheme.swift
+//  Draftsman
+//
+//  Created by Nayanda Haberty on 07/02/22.
+//
+
+import Foundation
+#if canImport(UIKit)
+import UIKit
+
+public final class PlannedLayoutScheme<View: UIView>: LayoutScheme<View> {
+    
+    override func buildCurrent(with startedConstaints: [NSLayoutConstraint]) -> ExtractedConstraints {
+        if context.applying {
+            (viewInScheme as? UIViewPlanned)?.selfPlanned = true
+        }
+        return super.buildCurrent(with: startedConstaints)
+    }
+    
+    public override func insert(@LayoutPlan _ layouter: () -> ViewPlan) -> Self {
+        if context.usingViewPlan, context.rootContextView == viewInScheme {
+            fatalError("Draftsman Error: Planned view or view controller should be managed its own content")
+        }
+        subPlanAccessed = true
+        self.subPlan.append(contentsOf: layouter().subPlan)
+        return self
+    }
+}
+#endif

--- a/Draftsman/Classes/Plan/PlannedLayoutScheme.swift
+++ b/Draftsman/Classes/Plan/PlannedLayoutScheme.swift
@@ -9,16 +9,16 @@ import Foundation
 #if canImport(UIKit)
 import UIKit
 
-public final class PlannedLayoutScheme<View: UIView>: LayoutScheme<View> {
+open class PlannedLayoutScheme<View: UIView>: LayoutScheme<View> {
     
     override func buildCurrent(with startedConstaints: [NSLayoutConstraint]) -> ExtractedConstraints {
         if context.applying {
-            (viewInScheme as? UIViewPlanned)?.selfPlanned = true
+            (viewInScheme as? UIViewPlanned)?.needPlanning = false
         }
         return super.buildCurrent(with: startedConstaints)
     }
     
-    public override func insert(@LayoutPlan _ layouter: () -> ViewPlan) -> Self {
+    open override func insert(@LayoutPlan _ layouter: () -> ViewPlan) -> Self {
         if context.usingViewPlan, context.rootContextView == viewInScheme {
             fatalError("Draftsman Error: Planned view or view controller should be managed its own content")
         }

--- a/Draftsman/Classes/Plan/RootViewPlan.swift
+++ b/Draftsman/Classes/Plan/RootViewPlan.swift
@@ -10,7 +10,6 @@ import Foundation
 import UIKit
 
 open class RootViewPlan: SchemeCollection {
-    weak var delegate: PlanDelegate?
     
     open override func build(for view: UIView) -> [NSLayoutConstraint] {
         buildAndExtractConstraint(for: view).toActivated
@@ -18,6 +17,7 @@ open class RootViewPlan: SchemeCollection {
     
     @discardableResult
     open override func apply(for view: UIView) -> [NSLayoutConstraint] {
+        context.applying = true
         context.rootContextController = view.nextViewController
         let constraints = buildAndExtractConstraint(for: view)
         NSLayoutConstraint.deactivate(constraints.toRemoved)
@@ -34,31 +34,18 @@ open class RootViewPlan: SchemeCollection {
     
     func buildWithContext(for view: UIView, _ builder: () -> ExtractedConstraints) -> ExtractedConstraints {
         context.currentView = view
-        if context.inViewPlan {
+        if context.usingViewPlan {
             removeSubviewThatNotInPlan(for: view)
         }
         return builder()
     }
     
-    func extractAllViewPlanIds() -> [String] {
-        subPlan.reduce([]) { partialResult, scheme in
-            var nextResult = partialResult
-            nextResult.append(contentsOf: scheme.managedViewPlanIds)
-            return nextResult
-        }.unique
-    }
-    
     func extractConstraints(for view: UIView, from constraints: [NSLayoutConstraint]) -> ExtractedConstraints {
         let currentConstraints = view.mostTopParentForConstraining.allConstraints
         let combinedConstraints = constraints.replaceAndResembleWithSimilar(from: currentConstraints)
-        if context.inViewPlan {
-            let viewPlanIds = extractAllViewPlanIds()
-            let removedConstraints = currentConstraints.filter { constraint in
-                for viewPlanId in viewPlanIds where constraint.isPartOf(viewPlanId: viewPlanId) {
-                    return true
-                }
-                return false
-            }
+        if context.usingViewPlan {
+            let viewPlanId = context.rootContextView.uniqueKey
+            let removedConstraints = currentConstraints.filter { $0.isPartOf(viewPlanId: viewPlanId) }
             return .init(toActivated: combinedConstraints, toRemoved: removedConstraints)
         }
         return .init(toActivated: combinedConstraints, toRemoved: [])

--- a/Draftsman/Classes/Plan/RootViewPlan.swift
+++ b/Draftsman/Classes/Plan/RootViewPlan.swift
@@ -11,6 +11,10 @@ import UIKit
 
 open class RootViewPlan: SchemeCollection {
     
+    public override init(subPlan: [ViewScheme]) {
+        super.init(subPlan: subPlan)
+    }
+    
     open override func build(for view: UIView) -> [NSLayoutConstraint] {
         buildAndExtractConstraint(for: view).toActivated
     }

--- a/Draftsman/Classes/Plan/SchemeCollection.swift
+++ b/Draftsman/Classes/Plan/SchemeCollection.swift
@@ -10,18 +10,29 @@ import Foundation
 import UIKit
 
 open class SchemeCollection: ViewPlan {
-    public var context: PlanContext
+    var _context: PlanContext?
+    public var context: PlanContext {
+        get {
+            guard let myContext = _context else {
+                let newContext: PlanContext = .default
+                _context = newContext
+                return newContext
+            }
+            return myContext
+        } set {
+            _context = newValue
+        }
+    }
     public var subPlan: [ViewScheme]
     var subPlanAccessed: Bool = false
     
     public init(subPlan: [ViewScheme]) {
-        self.context = PlanContext(currentView: UIView())
         self.subPlan = subPlan
     }
     
     open func build(for view: UIView) -> [NSLayoutConstraint] {
         context.currentView = view
-        if context.inViewPlan {
+        if context.usingViewPlan {
             removeSubviewThatNotInPlan(for: view)
         }
         let constraints = buildWholeScheme(for: view)
@@ -32,6 +43,7 @@ open class SchemeCollection: ViewPlan {
     
     @discardableResult
     open func apply(for view: UIView) -> [NSLayoutConstraint] {
+        context.applying = true
         context.rootContextController = view.nextViewController
         let constraints = build(for: view)
         NSLayoutConstraint.activate(constraints)
@@ -65,7 +77,7 @@ open class SchemeCollection: ViewPlan {
         }
         scheme.context = context
         let viewScheme = scheme.view
-        if context.inViewPlan, stack.arrangedSubviews.count > index {
+        if context.usingViewPlan, stack.arrangedSubviews.count > index {
             stack.insertArrangedSubview(viewScheme, at: index)
         } else {
             stack.addArrangedSubview(viewScheme)

--- a/Draftsman/Classes/Plan/ViewScheme+Axis.swift
+++ b/Draftsman/Classes/Plan/ViewScheme+Axis.swift
@@ -18,42 +18,44 @@ public extension ViewScheme {
         _ relation: LayoutRelation<CGFloat>,
         to anchor: NSLayoutYAxisAnchor,
         priority: UILayoutPriority? = nil) -> Self {
-        constraintBuilders.append(
-            ExplicitAxisConstraintBuilder(
-                anchor: view.topAnchor,
-                sign: .positive,
-                relation,
-                to: anchor,
-                priority: priority
+            guard let scheming = self as? ViewScheming else { return self }
+            scheming.constraintBuilders.append(
+                ExplicitAxisConstraintBuilder(
+                    anchor: view.topAnchor,
+                    sign: .positive,
+                    relation,
+                    to: anchor,
+                    priority: priority
+                )
             )
-        )
-        return self
-    }
+            return self
+        }
     
     @discardableResult
     func top(
         _ relation: LayoutRelation<CGFloat>,
         to anchor: RelatedAnchor<NSLayoutYAxisAnchor>,
         priority: UILayoutPriority? = nil) -> Self {
-        constraintBuilders.append(
-            AnonymousYAxisConstraintBuilder(
-                anchor: view.topAnchor,
-                sign: .positive,
-                relation,
-                to: anchor,
-                priority: priority
+            guard let scheming = self as? ViewScheming else { return self }
+            scheming.constraintBuilders.append(
+                AnonymousYAxisConstraintBuilder(
+                    anchor: view.topAnchor,
+                    sign: .positive,
+                    relation,
+                    to: anchor,
+                    priority: priority
+                )
             )
-        )
-        return self
-    }
+            return self
+        }
     
     @discardableResult
     func top(
         _ relation: LayoutRelation<CGFloat>,
         to anchor: AnonymousRelation,
         priority: UILayoutPriority? = nil) -> Self {
-        top(relation, to: .top(of: anchor), priority: priority)
-    }
+            top(relation, to: .top(of: anchor), priority: priority)
+        }
     
     // MARK: Right Anchor
     
@@ -62,42 +64,44 @@ public extension ViewScheme {
         _ relation: LayoutRelation<CGFloat>,
         to anchor: NSLayoutXAxisAnchor,
         priority: UILayoutPriority? = nil) -> Self {
-        constraintBuilders.append(
-            ExplicitAxisConstraintBuilder(
-                anchor: view.leftAnchor,
-                sign: .positive,
-                relation,
-                to: anchor,
-                priority: priority
+            guard let scheming = self as? ViewScheming else { return self }
+            scheming.constraintBuilders.append(
+                ExplicitAxisConstraintBuilder(
+                    anchor: view.leftAnchor,
+                    sign: .positive,
+                    relation,
+                    to: anchor,
+                    priority: priority
+                )
             )
-        )
-        return self
-    }
+            return self
+        }
     
     @discardableResult
     func left(
         _ relation: LayoutRelation<CGFloat>,
         to anchor: RelatedAnchor<NSLayoutXAxisAnchor>,
         priority: UILayoutPriority? = nil) -> Self {
-        constraintBuilders.append(
-            AnonymousXAxisConstraintBuilder(
-                anchor: view.leftAnchor,
-                sign: .positive,
-                relation,
-                to: anchor,
-                priority: priority
+            guard let scheming = self as? ViewScheming else { return self }
+            scheming.constraintBuilders.append(
+                AnonymousXAxisConstraintBuilder(
+                    anchor: view.leftAnchor,
+                    sign: .positive,
+                    relation,
+                    to: anchor,
+                    priority: priority
+                )
             )
-        )
-        return self
-    }
+            return self
+        }
     
     @discardableResult
     func left(
         _ relation: LayoutRelation<CGFloat>,
         to anchor: AnonymousRelation,
         priority: UILayoutPriority? = nil) -> Self {
-        left(relation, to: .left(of: anchor), priority: priority)
-    }
+            left(relation, to: .left(of: anchor), priority: priority)
+        }
     
     // MARK: Bottom Anchor
     
@@ -106,42 +110,44 @@ public extension ViewScheme {
         _ relation: LayoutRelation<CGFloat>,
         to anchor: NSLayoutYAxisAnchor,
         priority: UILayoutPriority? = nil) -> Self {
-        constraintBuilders.append(
-            ExplicitAxisConstraintBuilder(
-                anchor: view.bottomAnchor,
-                sign: .negative,
-                relation,
-                to: anchor,
-                priority: priority
+            guard let scheming = self as? ViewScheming else { return self }
+            scheming.constraintBuilders.append(
+                ExplicitAxisConstraintBuilder(
+                    anchor: view.bottomAnchor,
+                    sign: .negative,
+                    relation,
+                    to: anchor,
+                    priority: priority
+                )
             )
-        )
-        return self
-    }
+            return self
+        }
     
     @discardableResult
     func bottom(
         _ relation: LayoutRelation<CGFloat>,
         to anchor: RelatedAnchor<NSLayoutYAxisAnchor>,
         priority: UILayoutPriority? = nil) -> Self {
-        constraintBuilders.append(
-            AnonymousYAxisConstraintBuilder(
-                anchor: view.bottomAnchor,
-                sign: .negative,
-                relation,
-                to: anchor,
-                priority: priority
+            guard let scheming = self as? ViewScheming else { return self }
+            scheming.constraintBuilders.append(
+                AnonymousYAxisConstraintBuilder(
+                    anchor: view.bottomAnchor,
+                    sign: .negative,
+                    relation,
+                    to: anchor,
+                    priority: priority
+                )
             )
-        )
-        return self
-    }
+            return self
+        }
     
     @discardableResult
     func bottom(
         _ relation: LayoutRelation<CGFloat>,
         to anchor: AnonymousRelation,
         priority: UILayoutPriority? = nil) -> Self {
-        bottom(relation, to: .bottom(of: anchor), priority: priority)
-    }
+            bottom(relation, to: .bottom(of: anchor), priority: priority)
+        }
     
     // MARK: Right Anchor
     
@@ -150,42 +156,44 @@ public extension ViewScheme {
         _ relation: LayoutRelation<CGFloat>,
         to anchor: NSLayoutXAxisAnchor,
         priority: UILayoutPriority? = nil) -> Self {
-        constraintBuilders.append(
-            ExplicitAxisConstraintBuilder(
-                anchor: view.rightAnchor,
-                sign: .negative,
-                relation,
-                to: anchor,
-                priority: priority
+            guard let scheming = self as? ViewScheming else { return self }
+            scheming.constraintBuilders.append(
+                ExplicitAxisConstraintBuilder(
+                    anchor: view.rightAnchor,
+                    sign: .negative,
+                    relation,
+                    to: anchor,
+                    priority: priority
+                )
             )
-        )
-        return self
-    }
+            return self
+        }
     
     @discardableResult
     func right(
         _ relation: LayoutRelation<CGFloat>,
         to anchor: RelatedAnchor<NSLayoutXAxisAnchor>,
         priority: UILayoutPriority? = nil) -> Self {
-        constraintBuilders.append(
-            AnonymousXAxisConstraintBuilder(
-                anchor: view.rightAnchor,
-                sign: .negative,
-                relation,
-                to: anchor,
-                priority: priority
+            guard let scheming = self as? ViewScheming else { return self }
+            scheming.constraintBuilders.append(
+                AnonymousXAxisConstraintBuilder(
+                    anchor: view.rightAnchor,
+                    sign: .negative,
+                    relation,
+                    to: anchor,
+                    priority: priority
+                )
             )
-        )
-        return self
-    }
+            return self
+        }
     
     @discardableResult
     func right(
         _ relation: LayoutRelation<CGFloat>,
         to anchor: AnonymousRelation,
         priority: UILayoutPriority? = nil) -> Self {
-        right(relation, to: .right(of: anchor), priority: priority)
-    }
+            right(relation, to: .right(of: anchor), priority: priority)
+        }
     
     // MARK: Center Y Anchor
     
@@ -194,42 +202,44 @@ public extension ViewScheme {
         _ relation: LayoutRelation<CGFloat>,
         to anchor: NSLayoutYAxisAnchor,
         priority: UILayoutPriority? = nil) -> Self {
-        constraintBuilders.append(
-            ExplicitAxisConstraintBuilder(
-                anchor: view.centerYAnchor,
-                sign: .positive,
-                relation,
-                to: anchor,
-                priority: priority
+            guard let scheming = self as? ViewScheming else { return self }
+            scheming.constraintBuilders.append(
+                ExplicitAxisConstraintBuilder(
+                    anchor: view.centerYAnchor,
+                    sign: .positive,
+                    relation,
+                    to: anchor,
+                    priority: priority
+                )
             )
-        )
-        return self
-    }
+            return self
+        }
     
     @discardableResult
     func centerY(
         _ relation: LayoutRelation<CGFloat>,
         to anchor: RelatedAnchor<NSLayoutYAxisAnchor>,
         priority: UILayoutPriority? = nil) -> Self {
-        constraintBuilders.append(
-            AnonymousYAxisConstraintBuilder(
-                anchor: view.centerYAnchor,
-                sign: .positive,
-                relation,
-                to: anchor,
-                priority: priority
+            guard let scheming = self as? ViewScheming else { return self }
+            scheming.constraintBuilders.append(
+                AnonymousYAxisConstraintBuilder(
+                    anchor: view.centerYAnchor,
+                    sign: .positive,
+                    relation,
+                    to: anchor,
+                    priority: priority
+                )
             )
-        )
-        return self
-    }
+            return self
+        }
     
     @discardableResult
     func centerY(
         _ relation: LayoutRelation<CGFloat>,
         to anchor: AnonymousRelation,
         priority: UILayoutPriority? = nil) -> Self {
-        centerY(relation, to: .centerY(of: anchor), priority: priority)
-    }
+            centerY(relation, to: .centerY(of: anchor), priority: priority)
+        }
     
     // MARK: Center X Anchor
     
@@ -238,41 +248,43 @@ public extension ViewScheme {
         _ relation: LayoutRelation<CGFloat>,
         to anchor: NSLayoutXAxisAnchor,
         priority: UILayoutPriority? = nil) -> Self {
-        constraintBuilders.append(
-            ExplicitAxisConstraintBuilder(
-                anchor: view.centerXAnchor,
-                sign: .positive,
-                relation,
-                to: anchor,
-                priority: priority
+            guard let scheming = self as? ViewScheming else { return self }
+            scheming.constraintBuilders.append(
+                ExplicitAxisConstraintBuilder(
+                    anchor: view.centerXAnchor,
+                    sign: .positive,
+                    relation,
+                    to: anchor,
+                    priority: priority
+                )
             )
-        )
-        return self
-    }
+            return self
+        }
     
     @discardableResult
     func centerX(
         _ relation: LayoutRelation<CGFloat>,
         to anchor: RelatedAnchor<NSLayoutXAxisAnchor>,
         priority: UILayoutPriority? = nil) -> Self {
-        constraintBuilders.append(
-            AnonymousXAxisConstraintBuilder(
-                anchor: view.centerXAnchor,
-                sign: .positive,
-                relation,
-                to: anchor,
-                priority: priority
+            guard let scheming = self as? ViewScheming else { return self }
+            scheming.constraintBuilders.append(
+                AnonymousXAxisConstraintBuilder(
+                    anchor: view.centerXAnchor,
+                    sign: .positive,
+                    relation,
+                    to: anchor,
+                    priority: priority
+                )
             )
-        )
-        return self
-    }
+            return self
+        }
     
     @discardableResult
     func centerX(
         _ relation: LayoutRelation<CGFloat>,
         to anchor: AnonymousRelation,
         priority: UILayoutPriority? = nil) -> Self {
-        centerX(relation, to: .centerX(of: anchor), priority: priority)
-    }
+            centerX(relation, to: .centerX(of: anchor), priority: priority)
+        }
 }
 #endif

--- a/Draftsman/Classes/Plan/ViewScheme+Dimension.swift
+++ b/Draftsman/Classes/Plan/ViewScheme+Dimension.swift
@@ -19,17 +19,18 @@ public extension ViewScheme {
         multiplyBy multipier: CGFloat = 1,
         constant: CGFloat = 0,
         priority: UILayoutPriority? = nil) -> Self {
-        constraintBuilders.append(
-            RelationDimensionConstraintBuilder(
-                anchor: view.widthAnchor,
-                relation,
-                constant: constant,
-                multiplier: multipier,
-                priority: priority
+            guard let scheming = self as? ViewScheming else { return self }
+            scheming.constraintBuilders.append(
+                RelationDimensionConstraintBuilder(
+                    anchor: view.widthAnchor,
+                    relation,
+                    constant: constant,
+                    multiplier: multipier,
+                    priority: priority
+                )
             )
-        )
-        return self
-    }
+            return self
+        }
     
     @discardableResult
     func width(
@@ -37,17 +38,18 @@ public extension ViewScheme {
         multiplyBy multipier: CGFloat = 1,
         constant: CGFloat = 0,
         priority: UILayoutPriority? = nil) -> Self {
-        constraintBuilders.append(
-            AnonymousRelationDimensionConstraintBuilder(
-                anchor: view.widthAnchor,
-                relation,
-                constant: constant,
-                multiplier: multipier,
-                priority: priority
+            guard let scheming = self as? ViewScheming else { return self }
+            scheming.constraintBuilders.append(
+                AnonymousRelationDimensionConstraintBuilder(
+                    anchor: view.widthAnchor,
+                    relation,
+                    constant: constant,
+                    multiplier: multipier,
+                    priority: priority
+                )
             )
-        )
-        return self
-    }
+            return self
+        }
     
     @discardableResult
     func width(
@@ -55,19 +57,20 @@ public extension ViewScheme {
         multiplyBy multipier: CGFloat = 1,
         constant: CGFloat = 0,
         priority: UILayoutPriority? = nil) -> Self {
-        switch relation {
-        case .equalTo(let relation):
-            return width(.equalTo(.width(of: relation)), multiplyBy: multipier, constant: constant, priority: priority)
-        case .moreThanTo(let relation):
-            return width(.moreThanTo(.width(of: relation)), multiplyBy: multipier, constant: constant, priority: priority)
-        case .lessThanTo(let relation):
-            return width(.lessThanTo(.width(of: relation)), multiplyBy: multipier, constant: constant, priority: priority)
+            switch relation {
+            case .equalTo(let relation):
+                return width(.equalTo(.width(of: relation)), multiplyBy: multipier, constant: constant, priority: priority)
+            case .moreThanTo(let relation):
+                return width(.moreThanTo(.width(of: relation)), multiplyBy: multipier, constant: constant, priority: priority)
+            case .lessThanTo(let relation):
+                return width(.lessThanTo(.width(of: relation)), multiplyBy: multipier, constant: constant, priority: priority)
+            }
         }
-    }
     
     @discardableResult
     func width(_ relation: InterRelation<CGFloat>, priority: UILayoutPriority? = nil) -> Self {
-        constraintBuilders.append(
+        guard let scheming = self as? ViewScheming else { return self }
+        scheming.constraintBuilders.append(
             ExplicitDimensionConstraintBuilder(
                 anchor: view.widthAnchor,
                 relation,
@@ -85,17 +88,18 @@ public extension ViewScheme {
         multiplyBy multipier: CGFloat = 1,
         constant: CGFloat = 0,
         priority: UILayoutPriority? = nil) -> Self {
-        constraintBuilders.append(
-            RelationDimensionConstraintBuilder(
-                anchor: view.heightAnchor,
-                relation,
-                constant: constant,
-                multiplier: multipier,
-                priority: priority
+            guard let scheming = self as? ViewScheming else { return self }
+            scheming.constraintBuilders.append(
+                RelationDimensionConstraintBuilder(
+                    anchor: view.heightAnchor,
+                    relation,
+                    constant: constant,
+                    multiplier: multipier,
+                    priority: priority
+                )
             )
-        )
-        return self
-    }
+            return self
+        }
     
     @discardableResult
     func height(
@@ -103,17 +107,18 @@ public extension ViewScheme {
         multiplyBy multipier: CGFloat = 1,
         constant: CGFloat = 0,
         priority: UILayoutPriority? = nil) -> Self {
-        constraintBuilders.append(
-            AnonymousRelationDimensionConstraintBuilder(
-                anchor: view.heightAnchor,
-                relation,
-                constant: constant,
-                multiplier: multipier,
-                priority: priority
+            guard let scheming = self as? ViewScheming else { return self }
+            scheming.constraintBuilders.append(
+                AnonymousRelationDimensionConstraintBuilder(
+                    anchor: view.heightAnchor,
+                    relation,
+                    constant: constant,
+                    multiplier: multipier,
+                    priority: priority
+                )
             )
-        )
-        return self
-    }
+            return self
+        }
     
     @discardableResult
     func height(
@@ -121,19 +126,20 @@ public extension ViewScheme {
         multiplyBy multipier: CGFloat = 1,
         constant: CGFloat = 0,
         priority: UILayoutPriority? = nil) -> Self {
-        switch relation {
-        case .equalTo(let relation):
-            return height(.equalTo(.height(of: relation)), multiplyBy: multipier, constant: constant, priority: priority)
-        case .moreThanTo(let relation):
-            return height(.moreThanTo(.height(of: relation)), multiplyBy: multipier, constant: constant, priority: priority)
-        case .lessThanTo(let relation):
-            return height(.lessThanTo(.height(of: relation)), multiplyBy: multipier, constant: constant, priority: priority)
+            switch relation {
+            case .equalTo(let relation):
+                return height(.equalTo(.height(of: relation)), multiplyBy: multipier, constant: constant, priority: priority)
+            case .moreThanTo(let relation):
+                return height(.moreThanTo(.height(of: relation)), multiplyBy: multipier, constant: constant, priority: priority)
+            case .lessThanTo(let relation):
+                return height(.lessThanTo(.height(of: relation)), multiplyBy: multipier, constant: constant, priority: priority)
+            }
         }
-    }
     
     @discardableResult
     func height(_ relation: InterRelation<CGFloat>, priority: UILayoutPriority? = nil) -> Self {
-        constraintBuilders.append(
+        guard let scheming = self as? ViewScheming else { return self }
+        scheming.constraintBuilders.append(
             ExplicitDimensionConstraintBuilder(
                 anchor: view.heightAnchor,
                 relation,

--- a/Draftsman/Classes/Plan/ViewScheme+Shortcuts.swift
+++ b/Draftsman/Classes/Plan/ViewScheme+Shortcuts.swift
@@ -18,22 +18,24 @@ public extension ViewScheme {
         _ relation: LayoutRelation<CoordinateOffsets>,
         to view: UIView,
         priority: UILayoutPriority? = nil) -> Self {
-        let priority: UILayoutPriority = priority ?? context.mutatingPriority
-        centerX(relation.asXRelation, to: view.centerXAnchor, priority: priority)
-        centerY(relation.asYRelation, to: view.centerYAnchor, priority: priority)
-        return self
-    }
+            guard let scheming = self as? ViewScheming else { return self }
+            let priority: UILayoutPriority = priority ?? scheming.context.mutatingPriority
+            centerX(relation.asXRelation, to: view.centerXAnchor, priority: priority)
+            centerY(relation.asYRelation, to: view.centerYAnchor, priority: priority)
+            return self
+        }
     
     @discardableResult
     func center(
         _ relation: LayoutRelation<CoordinateOffsets>,
         to anchor: AnonymousRelation,
         priority: UILayoutPriority? = nil) -> Self {
-        let priority: UILayoutPriority = priority ?? context.mutatingPriority
-        centerX(relation.asXRelation, to: anchor, priority: priority)
-        centerY(relation.asYRelation, to: anchor, priority: priority)
-        return self
-    }
+            guard let scheming = self as? ViewScheming else { return self }
+            let priority: UILayoutPriority = priority ?? scheming.context.mutatingPriority
+            centerX(relation.asXRelation, to: anchor, priority: priority)
+            centerY(relation.asYRelation, to: anchor, priority: priority)
+            return self
+        }
     
     // MARK: Vertical Anchor
     
@@ -42,22 +44,24 @@ public extension ViewScheme {
         _ relation: LayoutRelation<InsetsConvertible>,
         to anchor: AnonymousRelation,
         priority: UILayoutPriority? = nil) -> Self {
-        let priority: UILayoutPriority = priority ?? context.mutatingPriority
-        top(relation.asTopRelation, to: anchor, priority: priority)
-        bottom(relation.asBottomRelation, to: anchor, priority: priority)
-        return self
-    }
+            guard let scheming = self as? ViewScheming else { return self }
+            let priority: UILayoutPriority = priority ?? scheming.context.mutatingPriority
+            top(relation.asTopRelation, to: anchor, priority: priority)
+            bottom(relation.asBottomRelation, to: anchor, priority: priority)
+            return self
+        }
     
     @discardableResult
     func vertical(
         _ relation: LayoutRelation<InsetsConvertible>,
         to view: UIView,
         priority: UILayoutPriority? = nil) -> Self {
-        let priority: UILayoutPriority = priority ?? context.mutatingPriority
-        top(relation.asTopRelation, to: view.topAnchor, priority: priority)
-        bottom(relation.asBottomRelation, to: view.bottomAnchor, priority: priority)
-        return self
-    }
+            guard let scheming = self as? ViewScheming else { return self }
+            let priority: UILayoutPriority = priority ?? scheming.context.mutatingPriority
+            top(relation.asTopRelation, to: view.topAnchor, priority: priority)
+            bottom(relation.asBottomRelation, to: view.bottomAnchor, priority: priority)
+            return self
+        }
     
     // MARK: Horizontal Anchor
     
@@ -66,22 +70,24 @@ public extension ViewScheme {
         _ relation: LayoutRelation<InsetsConvertible>,
         to view: UIView,
         priority: UILayoutPriority? = nil) -> Self {
-        let priority: UILayoutPriority = priority ?? context.mutatingPriority
-        left(relation.asLeftRelation, to: view.leftAnchor, priority: priority)
-        right(relation.asRightRelation, to: view.rightAnchor, priority: priority)
-        return self
-    }
+            guard let scheming = self as? ViewScheming else { return self }
+            let priority: UILayoutPriority = priority ?? scheming.context.mutatingPriority
+            left(relation.asLeftRelation, to: view.leftAnchor, priority: priority)
+            right(relation.asRightRelation, to: view.rightAnchor, priority: priority)
+            return self
+        }
     
     @discardableResult
     func horizontal(
         _ relation: LayoutRelation<InsetsConvertible>,
         to anchor: AnonymousRelation,
         priority: UILayoutPriority? = nil) -> Self {
-        let priority: UILayoutPriority = priority ?? context.mutatingPriority
-        left(relation.asLeftRelation, to: anchor, priority: priority)
-        right(relation.asRightRelation, to: anchor, priority: priority)
-        return self
-    }
+            guard let scheming = self as? ViewScheming else { return self }
+            let priority: UILayoutPriority = priority ?? scheming.context.mutatingPriority
+            left(relation.asLeftRelation, to: anchor, priority: priority)
+            right(relation.asRightRelation, to: anchor, priority: priority)
+            return self
+        }
     
     // MARK: Edges Anchor
     
@@ -90,11 +96,12 @@ public extension ViewScheme {
         _ relation: LayoutRelation<InsetsConvertible>,
         to anchor: AnonymousRelation,
         priority: UILayoutPriority? = nil) -> Self {
-        let priority: UILayoutPriority = priority ?? context.mutatingPriority
-        vertical(relation, to: anchor, priority: priority)
-        horizontal(relation, to: anchor, priority: priority)
-        return self
-    }
+            guard let scheming = self as? ViewScheming else { return self }
+            let priority: UILayoutPriority = priority ?? scheming.context.mutatingPriority
+            vertical(relation, to: anchor, priority: priority)
+            horizontal(relation, to: anchor, priority: priority)
+            return self
+        }
     
     // MARK: Size Anchor
     
@@ -102,11 +109,12 @@ public extension ViewScheme {
     func size(
         _ relation: InterRelation<CGSize>,
         priority: UILayoutPriority? = nil) -> Self {
-        let priority: UILayoutPriority = priority ?? context.mutatingPriority
-        height(relation.asHeightRelation, priority: priority)
-        width(relation.asHeightRelation, priority: priority)
-        return self
-    }
+            guard let scheming = self as? ViewScheming else { return self }
+            let priority: UILayoutPriority = priority ?? scheming.context.mutatingPriority
+            height(relation.asHeightRelation, priority: priority)
+            width(relation.asHeightRelation, priority: priority)
+            return self
+        }
     
     @discardableResult
     func size(
@@ -114,11 +122,12 @@ public extension ViewScheme {
         multiplyBy multipier: CGFloat = 1,
         constant: CGFloat = 0,
         priority: UILayoutPriority? = nil) -> Self {
-        let priority: UILayoutPriority = priority ?? context.mutatingPriority
-        height(relation.asHeightRelation, multiplyBy: multipier, constant: constant, priority: priority)
-        width(relation.asWidthRelation, multiplyBy: multipier, constant: constant, priority: priority)
-        return self
-    }
+            guard let scheming = self as? ViewScheming else { return self }
+            let priority: UILayoutPriority = priority ?? scheming.context.mutatingPriority
+            height(relation.asHeightRelation, multiplyBy: multipier, constant: constant, priority: priority)
+            width(relation.asWidthRelation, multiplyBy: multipier, constant: constant, priority: priority)
+            return self
+        }
     
     // MARK: Position Anchor
     
@@ -128,50 +137,52 @@ public extension ViewScheme {
         _ relation: LayoutRelation<InsetsConvertible>,
         to anchor: AnonymousRelation,
         priority: UILayoutPriority? = nil) -> Self {
-        let priority: UILayoutPriority = priority ?? context.mutatingPriority
-        for position in positions {
-            switch position {
-            case .top:
-                top(relation.asTopRelation, to: anchor, priority: priority)
-            case .bottom:
-                bottom(relation.asBottomRelation, to: anchor, priority: priority)
-            case .left:
-                left(relation.asLeftRelation, to: anchor, priority: priority)
-            case .right:
-                right(relation.asRightRelation, to: anchor, priority: priority)
+            guard let scheming = self as? ViewScheming else { return self }
+            let priority: UILayoutPriority = priority ?? scheming.context.mutatingPriority
+            for position in positions {
+                switch position {
+                case .top:
+                    top(relation.asTopRelation, to: anchor, priority: priority)
+                case .bottom:
+                    bottom(relation.asBottomRelation, to: anchor, priority: priority)
+                case .left:
+                    left(relation.asLeftRelation, to: anchor, priority: priority)
+                case .right:
+                    right(relation.asRightRelation, to: anchor, priority: priority)
+                }
             }
+            return self
         }
-        return self
-    }
     
     @discardableResult
     func at(
         _ viewRelation: RelatedPosition,
         _ relation: LayoutRelation<InsetsConvertible>,
         priority: UILayoutPriority? = nil) -> Self {
-        let priority: UILayoutPriority = priority ?? context.mutatingPriority
-        let position = viewRelation.position
-        let relatedView = viewRelation.view
-        switch position {
-        case .top:
-            bottom(relation.asBottomRelation, to: relatedView.topAnchor, priority: priority)
-        case .bottom:
-            top(relation.asTopRelation, to: relatedView.bottomAnchor, priority: priority)
-        case .left:
-            right(relation.asRightRelation, to: relatedView.leftAnchor, priority: priority)
-        case .right:
-            left(relation.asLeftRelation, to: relatedView.rightAnchor, priority: priority)
-        }
-        if viewRelation.shouldParallel {
+            guard let scheming = self as? ViewScheming else { return self }
+            let priority: UILayoutPriority = priority ?? scheming.context.mutatingPriority
+            let position = viewRelation.position
+            let relatedView = viewRelation.view
             switch position {
-            case .top, .bottom:
-                centerX(.equal, to: relatedView.centerXAnchor, priority: priority)
-            case .left, .right:
-                centerY(.equal, to: relatedView.centerYAnchor, priority: priority)
+            case .top:
+                bottom(relation.asBottomRelation, to: relatedView.topAnchor, priority: priority)
+            case .bottom:
+                top(relation.asTopRelation, to: relatedView.bottomAnchor, priority: priority)
+            case .left:
+                right(relation.asRightRelation, to: relatedView.leftAnchor, priority: priority)
+            case .right:
+                left(relation.asLeftRelation, to: relatedView.rightAnchor, priority: priority)
             }
+            if viewRelation.shouldParallel {
+                switch position {
+                case .top, .bottom:
+                    centerX(.equal, to: relatedView.centerXAnchor, priority: priority)
+                case .left, .right:
+                    centerY(.equal, to: relatedView.centerYAnchor, priority: priority)
+                }
+            }
+            return self
         }
-        return self
-    }
     
     // MARK: Between Anchor
     
@@ -181,17 +192,18 @@ public extension ViewScheme {
         and otherView: UIView,
         _ position: MiddlePosition,
         priority: UILayoutPriority? = nil) -> Self {
-        let priority: UILayoutPriority = priority ?? context.mutatingPriority
-        switch position {
-        case .vertically(let relation):
-            top(relation.asTopRelation, to: view.bottomAnchor, priority: priority)
-            bottom(relation.asBottomRelation, to: otherView.topAnchor, priority: priority)
-        case .horizontally(let relation):
-            left(relation.asLeftRelation, to: view.rightAnchor, priority: priority)
-            right(relation.asRightRelation, to: view.leftAnchor, priority: priority)
+            guard let scheming = self as? ViewScheming else { return self }
+            let priority: UILayoutPriority = priority ?? scheming.context.mutatingPriority
+            switch position {
+            case .vertically(let relation):
+                top(relation.asTopRelation, to: view.bottomAnchor, priority: priority)
+                bottom(relation.asBottomRelation, to: otherView.topAnchor, priority: priority)
+            case .horizontally(let relation):
+                left(relation.asLeftRelation, to: view.rightAnchor, priority: priority)
+                right(relation.asRightRelation, to: view.leftAnchor, priority: priority)
+            }
+            return self
         }
-        return self
-    }
 }
 
 public extension Array where Element == LayoutEdge {

--- a/Draftsman/Classes/Plan/ViewScheme.swift
+++ b/Draftsman/Classes/Plan/ViewScheme.swift
@@ -1,0 +1,43 @@
+//
+//  ViewScheme.swift
+//  Draftsman
+//
+//  Created by Nayanda Haberty on 07/02/22.
+//
+
+import Foundation
+#if canImport(UIKit)
+import UIKit
+
+// MARK: ViewScheme
+
+protocol ViewScheming: ViewScheme, ViewPlaning {
+    var constraintBuilders: [LayoutConstraintBuilder] { get set }
+    var isStackContent: Bool { get set }
+}
+
+public protocol ViewScheme: ViewPlan {
+    var view: UIView { get }
+    var isStackContent: Bool { get }
+    func insert(@LayoutPlan _ layouter: () -> ViewPlan) -> Self
+    func build() -> [NSLayoutConstraint]
+    @discardableResult
+    func apply() -> [NSLayoutConstraint]
+}
+
+public protocol StackScheme: ViewScheme {
+    func insertStacked(@LayoutPlan _ layouter: () -> ViewPlan) -> Self
+}
+
+public extension ViewScheme {
+    
+    func build() -> [NSLayoutConstraint] {
+        build(for: view)
+    }
+    
+    @discardableResult
+    func apply() -> [NSLayoutConstraint] {
+        apply(for: view)
+    }
+}
+#endif

--- a/Draftsman/Classes/Planned/Fragment.swift
+++ b/Draftsman/Classes/Planned/Fragment.swift
@@ -22,6 +22,7 @@ public extension Fragment {
 public extension Fragment where Self: UIView {
     
     func applyPlan(delegate: PlanDelegate?) {
+        selfPlanned = true
         fragmentWillPlanContent()
         let scheme = LayoutScheme(view: self, subPlan: viewPlan.subPlan, originalViewPlanId: self.uniqueKey)
         scheme.delegate = delegate

--- a/Draftsman/Classes/Planned/Fragment.swift
+++ b/Draftsman/Classes/Planned/Fragment.swift
@@ -22,10 +22,9 @@ public extension Fragment {
 public extension Fragment where Self: UIView {
     
     func applyPlan(delegate: PlanDelegate?) {
-        selfPlanned = true
         fragmentWillPlanContent()
-        let scheme = LayoutScheme(view: self, subPlan: viewPlan.subPlan, originalViewPlanId: self.uniqueKey)
-        scheme.delegate = delegate
+        let scheme = PlannedLayoutScheme(view: self, subPlan: viewPlan.subPlan)
+        scheme.context = PlanContext(delegate: delegate, rootContextView: self, usingViewPlan: true)
         scheme.apply()
         DispatchQueue.main.async { [weak self] in
             self?.layoutIfNeeded()

--- a/Draftsman/Classes/Planned/FragmentCell.swift
+++ b/Draftsman/Classes/Planned/FragmentCell.swift
@@ -17,6 +17,7 @@ public protocol FragmentCell: Fragment where Self: UIView {
 
 public extension FragmentCell {
     func applyPlan(delegate: PlanDelegate?) {
+        selfPlanned = true
         fragmentWillPlanContent()
         let scheme = LayoutScheme(view: self.contentView, subPlan: viewPlan.subPlan, originalViewPlanId: self.uniqueKey)
         scheme.delegate = delegate

--- a/Draftsman/Classes/Planned/FragmentCell.swift
+++ b/Draftsman/Classes/Planned/FragmentCell.swift
@@ -17,10 +17,9 @@ public protocol FragmentCell: Fragment where Self: UIView {
 
 public extension FragmentCell {
     func applyPlan(delegate: PlanDelegate?) {
-        selfPlanned = true
         fragmentWillPlanContent()
-        let scheme = LayoutScheme(view: self.contentView, subPlan: viewPlan.subPlan, originalViewPlanId: self.uniqueKey)
-        scheme.delegate = delegate
+        let scheme = PlannedLayoutScheme(view: self.contentView, subPlan: viewPlan.subPlan)
+        scheme.context = PlanContext(delegate: delegate, rootContextView: self.contentView, usingViewPlan: true)
         scheme.apply()
         fragmentDidPlanContent()
     }

--- a/Draftsman/Classes/Planned/FragmentView.swift
+++ b/Draftsman/Classes/Planned/FragmentView.swift
@@ -25,7 +25,6 @@ open class FragmentView: UIView, Fragment {
     open func fragmentDidLayoutForTheFirstTime() {}
     
     public func applyPlan(delegate: PlanDelegate?) {
-        selfPlanned = true
         applyScheme(delegate: delegate)
         DispatchQueue.main.async { [weak self] in
             self?.layoutIfNeeded()
@@ -57,8 +56,8 @@ open class FragmentView: UIView, Fragment {
             fragmentDidPlanContent()
             notifyViewDidPlanned()
         }
-        let scheme = LayoutScheme(view: self, subPlan: viewPlan.subPlan, originalViewPlanId: self.uniqueKey)
-        scheme.delegate = delegate
+        let scheme = PlannedLayoutScheme(view: self, subPlan: viewPlan.subPlan)
+        scheme.context = PlanContext(delegate: delegate, rootContextView: self, usingViewPlan: true)
         scheme.apply()
     }
 }

--- a/Draftsman/Classes/Planned/FragmentView.swift
+++ b/Draftsman/Classes/Planned/FragmentView.swift
@@ -25,6 +25,7 @@ open class FragmentView: UIView, Fragment {
     open func fragmentDidLayoutForTheFirstTime() {}
     
     public func applyPlan(delegate: PlanDelegate?) {
+        selfPlanned = true
         applyScheme(delegate: delegate)
         DispatchQueue.main.async { [weak self] in
             self?.layoutIfNeeded()

--- a/Draftsman/Classes/Planned/Planned.swift
+++ b/Draftsman/Classes/Planned/Planned.swift
@@ -10,7 +10,7 @@ import Foundation
 import UIKit
 
 public protocol Planned {
-    var selfPlanned: Bool { get }
+    var needPlanning: Bool { get }
     
     @LayoutPlan
     var viewPlan: ViewPlan { get }
@@ -27,20 +27,20 @@ public extension Planned {
 typealias UIViewPlanned = UIView & Planned
 
 extension UIView.AssociatedKey {
-    static var selfPlanned: String = "draftsman_Self_Planned"
+    static var needPlanning: String = "draftsman_Self_Planned"
 }
 
 public extension Planned where Self: UIView {
     
-    internal(set) var selfPlanned: Bool {
+    internal(set) var needPlanning: Bool {
         get {
             (objc_getAssociatedObject(
-                self, &AssociatedKey.selfPlanned) as? NSNumber
-            )?.boolValue ?? false
+                self, &AssociatedKey.needPlanning) as? NSNumber
+            )?.boolValue ?? true
         }
         set {
             objc_setAssociatedObject(
-                self, &AssociatedKey.selfPlanned,
+                self, &AssociatedKey.needPlanning,
                 NSNumber(value: newValue),
                 .OBJC_ASSOCIATION_RETAIN
             )
@@ -48,7 +48,6 @@ public extension Planned where Self: UIView {
     }
     
     func applyPlan(delegate: PlanDelegate?) {
-        selfPlanned = true
         let scheme = PlannedLayoutScheme(view: self, subPlan: viewPlan.subPlan)
         scheme.context = PlanContext(delegate: delegate, rootContextView: self, usingViewPlan: true)
         scheme.apply()
@@ -60,17 +59,17 @@ public extension Planned where Self: UIView {
 
 public extension Planned where Self: UIViewController {
     
-    internal(set) var selfPlanned: Bool {
+    internal(set) var needPlanning: Bool {
         get {
             (objc_getAssociatedObject(
                 self,
-                &UIView.AssociatedKey.selfPlanned) as? NSNumber
+                &UIView.AssociatedKey.needPlanning) as? NSNumber
             )?.boolValue ?? true
         }
         set {
             objc_setAssociatedObject(
                 self,
-                &UIView.AssociatedKey.selfPlanned,
+                &UIView.AssociatedKey.needPlanning,
                 NSNumber(value: newValue),
                 .OBJC_ASSOCIATION_RETAIN
             )

--- a/Draftsman/Classes/Planned/Planned.swift
+++ b/Draftsman/Classes/Planned/Planned.swift
@@ -24,6 +24,8 @@ public extension Planned {
     }
 }
 
+typealias UIViewPlanned = UIView & Planned
+
 extension UIView.AssociatedKey {
     static var selfPlanned: String = "draftsman_Self_Planned"
 }
@@ -47,8 +49,8 @@ public extension Planned where Self: UIView {
     
     func applyPlan(delegate: PlanDelegate?) {
         selfPlanned = true
-        let scheme = LayoutScheme(view: self, subPlan: viewPlan.subPlan, originalViewPlanId:  self.uniqueKey)
-        scheme.delegate = delegate
+        let scheme = PlannedLayoutScheme(view: self, subPlan: viewPlan.subPlan)
+        scheme.context = PlanContext(delegate: delegate, rootContextView: self, usingViewPlan: true)
         scheme.apply()
         DispatchQueue.main.async { [weak self] in
             self?.layoutIfNeeded()
@@ -74,9 +76,8 @@ public extension Planned where Self: UIViewController {
     }
     
     func applyPlan(delegate: PlanDelegate?) {
-        selfPlanned = true
-        let scheme = LayoutScheme(view: self.view, subPlan: viewPlan.subPlan, originalViewPlanId:  self.uniqueKey)
-        scheme.delegate = delegate
+        let scheme = PlannedLayoutScheme(view: self.view, subPlan: viewPlan.subPlan)
+        scheme.context = PlanContext(delegate: delegate, rootContextView: self.view, usingViewPlan: true)
         scheme.apply()
         DispatchQueue.main.async { [weak self] in
             self?.view.layoutIfNeeded()

--- a/Draftsman/Classes/Planned/Planned.swift
+++ b/Draftsman/Classes/Planned/Planned.swift
@@ -10,6 +10,8 @@ import Foundation
 import UIKit
 
 public protocol Planned {
+    var selfPlanned: Bool { get }
+    
     @LayoutPlan
     var viewPlan: ViewPlan { get }
     
@@ -22,8 +24,29 @@ public extension Planned {
     }
 }
 
+extension UIView.AssociatedKey {
+    static var selfPlanned: String = "draftsman_Self_Planned"
+}
+
 public extension Planned where Self: UIView {
+    
+    internal(set) var selfPlanned: Bool {
+        get {
+            (objc_getAssociatedObject(
+                self, AssociatedKey.selfPlanned) as? NSNumber
+            )?.boolValue ?? false
+        }
+        set {
+            objc_setAssociatedObject(
+                self, AssociatedKey.selfPlanned,
+                NSNumber(value: newValue),
+                .OBJC_ASSOCIATION_RETAIN
+            )
+        }
+    }
+    
     func applyPlan(delegate: PlanDelegate?) {
+        selfPlanned = true
         let scheme = LayoutScheme(view: self, subPlan: viewPlan.subPlan, originalViewPlanId:  self.uniqueKey)
         scheme.delegate = delegate
         scheme.apply()
@@ -34,7 +57,24 @@ public extension Planned where Self: UIView {
 }
 
 public extension Planned where Self: UIViewController {
+    
+    internal(set) var selfPlanned: Bool {
+        get {
+            (objc_getAssociatedObject(
+                self, UIView.AssociatedKey.selfPlanned) as? NSNumber
+            )?.boolValue ?? true
+        }
+        set {
+            objc_setAssociatedObject(
+                self, UIView.AssociatedKey.selfPlanned,
+                NSNumber(value: newValue),
+                .OBJC_ASSOCIATION_RETAIN
+            )
+        }
+    }
+    
     func applyPlan(delegate: PlanDelegate?) {
+        selfPlanned = true
         let scheme = LayoutScheme(view: self.view, subPlan: viewPlan.subPlan, originalViewPlanId:  self.uniqueKey)
         scheme.delegate = delegate
         scheme.apply()

--- a/Draftsman/Classes/Planned/Planned.swift
+++ b/Draftsman/Classes/Planned/Planned.swift
@@ -35,12 +35,12 @@ public extension Planned where Self: UIView {
     internal(set) var selfPlanned: Bool {
         get {
             (objc_getAssociatedObject(
-                self, AssociatedKey.selfPlanned) as? NSNumber
+                self, &AssociatedKey.selfPlanned) as? NSNumber
             )?.boolValue ?? false
         }
         set {
             objc_setAssociatedObject(
-                self, AssociatedKey.selfPlanned,
+                self, &AssociatedKey.selfPlanned,
                 NSNumber(value: newValue),
                 .OBJC_ASSOCIATION_RETAIN
             )
@@ -63,12 +63,14 @@ public extension Planned where Self: UIViewController {
     internal(set) var selfPlanned: Bool {
         get {
             (objc_getAssociatedObject(
-                self, UIView.AssociatedKey.selfPlanned) as? NSNumber
+                self,
+                &UIView.AssociatedKey.selfPlanned) as? NSNumber
             )?.boolValue ?? true
         }
         set {
             objc_setAssociatedObject(
-                self, UIView.AssociatedKey.selfPlanned,
+                self,
+                &UIView.AssociatedKey.selfPlanned,
                 NSNumber(value: newValue),
                 .OBJC_ASSOCIATION_RETAIN
             )

--- a/Draftsman/Classes/Utilities/Array+Extensions.swift
+++ b/Draftsman/Classes/Utilities/Array+Extensions.swift
@@ -53,15 +53,4 @@ extension Sequence where Element == PlanComponent {
         }
     }
 }
-
-extension Sequence where Element == ViewScheme {
-    func markUnmarked(with viewPlanId: String) {
-        forEach {
-            if $0.viewPlanId == nil {
-                $0.viewPlanId = viewPlanId
-            }
-            $0.subPlan.markUnmarked(with: viewPlanId)
-        }
-    }
-}
 #endif

--- a/Example/Pods/Pods.xcodeproj/project.pbxproj
+++ b/Example/Pods/Pods.xcodeproj/project.pbxproj
@@ -118,6 +118,7 @@
 		B8A111BEADE508D1C85DF8B7891628AE /* ElementsEqual.swift in Sources */ = {isa = PBXBuildFile; fileRef = E06F0E8ECAD7A240553A0F4EA5CCC958 /* ElementsEqual.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble"; }; };
 		BB2F590DC59E2BE160EA2EDB7EBD01B6 /* NSLayoutConstraint+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F66181D56D23B1FE4BC96387BDA9DD7 /* NSLayoutConstraint+Extensions.swift */; };
 		BB8370B2AD5EDA60D508B0A9FA16E4D9 /* EndWith.swift in Sources */ = {isa = PBXBuildFile; fileRef = 93240AE0AA208B922E7BC34313114DD3 /* EndWith.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble"; }; };
+		BB8DF63A27B1294500CC78BC /* PlannedLayoutScheme.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB8DF63927B1294500CC78BC /* PlannedLayoutScheme.swift */; };
 		BCE752B0FAA9E4070407EDDD03C06922 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = CA8B94E9D3B433157168D1EECCEC11CD /* Foundation.framework */; };
 		C03116C765F1A8893559730965ECBAD8 /* Nimble-umbrella.h in Headers */ = {isa = PBXBuildFile; fileRef = 2FDB14BCB3B236EF999878622BAC1A42 /* Nimble-umbrella.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		C0DEEBAA700A340E1427641E9169582B /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = CA8B94E9D3B433157168D1EECCEC11CD /* Foundation.framework */; };
@@ -248,7 +249,7 @@
 		1493286F8745FCAAAFF7E2D5E18B9C93 /* ViewScheme+Axis.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "ViewScheme+Axis.swift"; sourceTree = "<group>"; };
 		156A86AA48B02C848BA1E427F87E103A /* DispatchTimeInterval.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = DispatchTimeInterval.swift; path = Sources/Nimble/Utils/DispatchTimeInterval.swift; sourceTree = "<group>"; };
 		1813D44C0293100C09DA3E39800A03D9 /* NMBExpectation.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = NMBExpectation.swift; path = Sources/Nimble/Adapters/NMBExpectation.swift; sourceTree = "<group>"; };
-		1B36C5E9E06B543E08334AC747DE7D7E /* mach_excServer.c */ = {isa = PBXFileReference; includeInIndex = 1; name = mach_excServer.c; path = Carthage/Checkouts/CwlPreconditionTesting/Sources/CwlMachBadInstructionHandler/mach_excServer.c; sourceTree = "<group>"; };
+		1B36C5E9E06B543E08334AC747DE7D7E /* mach_excServer.c */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.c; name = mach_excServer.c; path = Carthage/Checkouts/CwlPreconditionTesting/Sources/CwlMachBadInstructionHandler/mach_excServer.c; sourceTree = "<group>"; };
 		1E17FF6CF6E62592E1469FCDE2665247 /* QuickSpecBase.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = QuickSpecBase.h; path = Sources/QuickObjCRuntime/include/QuickSpecBase.h; sourceTree = "<group>"; };
 		1EBF379F44CEE2ED81DC82EB0623A7E4 /* Draftsman */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; name = Draftsman; path = Draftsman.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		1FE0EB83F325D5B217F39973B1EB0F85 /* LayoutPlan.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LayoutPlan.swift; sourceTree = "<group>"; };
@@ -322,7 +323,7 @@
 		79835BDC43646D9D83D52AB9C57E86E8 /* Nimble-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "Nimble-dummy.m"; sourceTree = "<group>"; };
 		79BD07A656BB3D438A402B060D5FFDAE /* KeyboardLayoutGuide.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = KeyboardLayoutGuide.swift; path = Clavier/Classes/KeyboardLayoutGuide.swift; sourceTree = "<group>"; };
 		7AC83CAD113C3B6F7161CB4D80FFA4D7 /* Builder.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = Builder.debug.xcconfig; sourceTree = "<group>"; };
-		7AE1FB49FD807DC89A88B2B4DA47FA7F /* README.md */ = {isa = PBXFileReference; includeInIndex = 1; path = README.md; sourceTree = "<group>"; };
+		7AE1FB49FD807DC89A88B2B4DA47FA7F /* README.md */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = net.daringfireball.markdown; path = README.md; sourceTree = "<group>"; };
 		7C4E4F281736742CBF74053C19D08AC9 /* CommonExtensions.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = CommonExtensions.swift; sourceTree = "<group>"; };
 		7E57DB1A03960B4457E319906BD0D903 /* Clavier.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = Clavier.release.xcconfig; sourceTree = "<group>"; };
 		7F6C0A51228B535B727274D49A2F70B5 /* SuiteHooks.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = SuiteHooks.swift; path = Sources/Quick/Hooks/SuiteHooks.swift; sourceTree = "<group>"; };
@@ -350,7 +351,7 @@
 		9CFAB2D6A89775C05A45AF717DE4215C /* QCKDSL.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = QCKDSL.h; path = Sources/QuickObjectiveC/DSL/QCKDSL.h; sourceTree = "<group>"; };
 		9CFB6D77ACDECC048CB77E4604F606B0 /* DSL.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = DSL.swift; path = Sources/Quick/DSL/DSL.swift; sourceTree = "<group>"; };
 		9D42BFE2E1A3EC3C06AD313E87693E11 /* Anchor.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = Anchor.swift; sourceTree = "<group>"; };
-		9D940727FF8FB9C785EB98E56350EF41 /* Podfile */ = {isa = PBXFileReference; explicitFileType = text.script.ruby; includeInIndex = 1; indentWidth = 2; lastKnownFileType = text; name = Podfile; path = ../Podfile; sourceTree = SOURCE_ROOT; tabWidth = 2; xcLanguageSpecificationIdentifier = xcode.lang.ruby; };
+		9D940727FF8FB9C785EB98E56350EF41 /* Podfile */ = {isa = PBXFileReference; explicitFileType = text.script.ruby; includeInIndex = 1; indentWidth = 2; name = Podfile; path = ../Podfile; sourceTree = SOURCE_ROOT; tabWidth = 2; xcLanguageSpecificationIdentifier = xcode.lang.ruby; };
 		9DCE3EC18A255676B9E6C67A3CC92BE7 /* Array+Extensions.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "Array+Extensions.swift"; sourceTree = "<group>"; };
 		9E0BD201575158BF23B6C28BCB02C25D /* Builder-prefix.pch */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "Builder-prefix.pch"; sourceTree = "<group>"; };
 		A09596B5B9C4062684585D98B4510800 /* BeGreaterThan.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = BeGreaterThan.swift; path = Sources/Nimble/Matchers/BeGreaterThan.swift; sourceTree = "<group>"; };
@@ -383,12 +384,13 @@
 		B910CA58DDB83E4E502F65F2EE94A383 /* Quick-Info.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = "Quick-Info.plist"; sourceTree = "<group>"; };
 		B98BEE20D4ADA7BAE7226CB4669088B5 /* Builder-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "Builder-dummy.m"; sourceTree = "<group>"; };
 		BAE263041362D074978BB3B577DF0A05 /* Nimble */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; name = Nimble; path = Nimble.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		BB8DF63927B1294500CC78BC /* PlannedLayoutScheme.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlannedLayoutScheme.swift; sourceTree = "<group>"; };
 		BD06FE6BA5E4955C3F40CEE9D13ADE2C /* FragmentCell.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = FragmentCell.swift; sourceTree = "<group>"; };
 		BE45FDE30054808E0F6ABE006F76E50D /* NMBExceptionCapture.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = NMBExceptionCapture.m; path = Sources/NimbleObjectiveC/NMBExceptionCapture.m; sourceTree = "<group>"; };
 		BF229AEEB0F1D4292FF6F14A44B60EC9 /* QuickSpecBase.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = QuickSpecBase.m; path = Sources/QuickObjCRuntime/QuickSpecBase.m; sourceTree = "<group>"; };
 		BF4E369EA8E3F9FFE7451ED48E4F0B86 /* BeNil.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = BeNil.swift; path = Sources/Nimble/Matchers/BeNil.swift; sourceTree = "<group>"; };
 		C08CE3E1D2CF36310D2FBBC1C78C9896 /* Draftsman-prefix.pch */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "Draftsman-prefix.pch"; sourceTree = "<group>"; };
-		C41D8C2C8C8C632AF514055BA823EBC4 /* LICENSE */ = {isa = PBXFileReference; includeInIndex = 1; path = LICENSE; sourceTree = "<group>"; };
+		C41D8C2C8C8C632AF514055BA823EBC4 /* LICENSE */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; path = LICENSE; sourceTree = "<group>"; };
 		C49F9DCEE05CBA771AE9EFCC3BF08087 /* NMBObjCMatcher.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = NMBObjCMatcher.swift; path = Sources/Nimble/Adapters/NMBObjCMatcher.swift; sourceTree = "<group>"; };
 		C7BC9CFD2B045F178639E7C2CFC5C3B8 /* HaveCount.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = HaveCount.swift; path = Sources/Nimble/Matchers/HaveCount.swift; sourceTree = "<group>"; };
 		C8186729509513E50B2C979D2BCC95F2 /* LayoutSchemeBuilder.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LayoutSchemeBuilder.swift; sourceTree = "<group>"; };
@@ -404,7 +406,7 @@
 		D1A003A0D47CE4F22D9216947864289A /* BeAnInstanceOf.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = BeAnInstanceOf.swift; path = Sources/Nimble/Matchers/BeAnInstanceOf.swift; sourceTree = "<group>"; };
 		D42B2153C1DC5897D79DE5C9E4B09E76 /* RootViewPlan.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = RootViewPlan.swift; sourceTree = "<group>"; };
 		D606CD41E603216617EF58342349725F /* Callsite.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Callsite.swift; path = Sources/Quick/Callsite.swift; sourceTree = "<group>"; };
-		D7D6C883F9F91FDFAF80DBF3D804A942 /* Draftsman.podspec */ = {isa = PBXFileReference; explicitFileType = text.script.ruby; includeInIndex = 1; indentWidth = 2; lastKnownFileType = text; path = Draftsman.podspec; sourceTree = "<group>"; tabWidth = 2; xcLanguageSpecificationIdentifier = xcode.lang.ruby; };
+		D7D6C883F9F91FDFAF80DBF3D804A942 /* Draftsman.podspec */ = {isa = PBXFileReference; explicitFileType = text.script.ruby; includeInIndex = 1; indentWidth = 2; path = Draftsman.podspec; sourceTree = "<group>"; tabWidth = 2; xcLanguageSpecificationIdentifier = xcode.lang.ruby; };
 		D822AD998D0C56C22F372DB5FAFF0411 /* Quick.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = Quick.debug.xcconfig; sourceTree = "<group>"; };
 		D8F5B9826C1B518B1C86E0F17D4CB7EF /* Quick-umbrella.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "Quick-umbrella.h"; sourceTree = "<group>"; };
 		D9168FF56B0F130B5CCA4C554B98A090 /* Nimble-prefix.pch */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "Nimble-prefix.pch"; sourceTree = "<group>"; };
@@ -529,7 +531,6 @@
 				0560EA6FFBA1B17A02002D5915150506 /* PropertyAssigner.swift */,
 				B00DBDFA4BC16360493446BD66161D8A /* Support Files */,
 			);
-			name = Builder;
 			path = Builder;
 			sourceTree = "<group>";
 		};
@@ -549,7 +550,6 @@
 				79BD07A656BB3D438A402B060D5FFDAE /* KeyboardLayoutGuide.swift */,
 				908B0C650FA615764CC436A5E35BB10B /* Support Files */,
 			);
-			name = Clavier;
 			path = Clavier;
 			sourceTree = "<group>";
 		};
@@ -622,6 +622,7 @@
 				1493286F8745FCAAAFF7E2D5E18B9C93 /* ViewScheme+Axis.swift */,
 				7234D172C56D017190329F457D41B3F0 /* ViewScheme+Dimension.swift */,
 				72EC3DA616BAFB9D2874A5845E57ED6B /* ViewScheme+Shortcuts.swift */,
+				BB8DF63927B1294500CC78BC /* PlannedLayoutScheme.swift */,
 			);
 			name = Plan;
 			path = Draftsman/Classes/Plan;
@@ -825,7 +826,6 @@
 				2D091D48835AFAF41D9870EDA497811C /* XCTestSuite+QuickTestSuiteBuilder.m */,
 				67264F229D8F9C1A0017C175BDFF52DA /* Support Files */,
 			);
-			name = Quick;
 			path = Quick;
 			sourceTree = "<group>";
 		};
@@ -905,7 +905,6 @@
 				54691D26C2EF6C4E359F084876868FAD /* XCTestObservationCenter+Register.m */,
 				A16580AA76A494F1DE5D31C08F6D0DA4 /* Support Files */,
 			);
-			name = Nimble;
 			path = Nimble;
 			sourceTree = "<group>";
 		};
@@ -1231,6 +1230,7 @@
 				08A9A37584E70BB2D9C9FB6EF2CC3D40 /* PlanConvertible.swift in Sources */,
 				3B8D6664E5BC861B1F4F51EFA80430E7 /* PlanDelegate.swift in Sources */,
 				788482FD4DE57DF0507ACDB1370B30CA /* Planned.swift in Sources */,
+				BB8DF63A27B1294500CC78BC /* PlannedLayoutScheme.swift in Sources */,
 				977B971036EF83A127E6134ED6296817 /* PriorityConvertible.swift in Sources */,
 				AF0B3A29CFB2B1E5209829147087231F /* RootViewPlan.swift in Sources */,
 				2C7A04990D3ADC0CD9546F515B720640 /* SchemeCollection.swift in Sources */,
@@ -1789,8 +1789,7 @@
 				MTL_FAST_MATH = YES;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				STRIP_INSTALLED_PRODUCT = NO;
-				SWIFT_COMPILATION_MODE = wholemodule;
-				SWIFT_OPTIMIZATION_LEVEL = "-O";
+				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
 				SWIFT_VERSION = 5.0;
 				SYMROOT = "${SRCROOT}/../build";
 			};

--- a/Example/Pods/Pods.xcodeproj/project.pbxproj
+++ b/Example/Pods/Pods.xcodeproj/project.pbxproj
@@ -119,6 +119,7 @@
 		BB2F590DC59E2BE160EA2EDB7EBD01B6 /* NSLayoutConstraint+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F66181D56D23B1FE4BC96387BDA9DD7 /* NSLayoutConstraint+Extensions.swift */; };
 		BB8370B2AD5EDA60D508B0A9FA16E4D9 /* EndWith.swift in Sources */ = {isa = PBXBuildFile; fileRef = 93240AE0AA208B922E7BC34313114DD3 /* EndWith.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble"; }; };
 		BB8DF63A27B1294500CC78BC /* PlannedLayoutScheme.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB8DF63927B1294500CC78BC /* PlannedLayoutScheme.swift */; };
+		BB8DF63C27B1593E00CC78BC /* ViewScheme.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB8DF63B27B1593E00CC78BC /* ViewScheme.swift */; };
 		BCE752B0FAA9E4070407EDDD03C06922 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = CA8B94E9D3B433157168D1EECCEC11CD /* Foundation.framework */; };
 		C03116C765F1A8893559730965ECBAD8 /* Nimble-umbrella.h in Headers */ = {isa = PBXBuildFile; fileRef = 2FDB14BCB3B236EF999878622BAC1A42 /* Nimble-umbrella.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		C0DEEBAA700A340E1427641E9169582B /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = CA8B94E9D3B433157168D1EECCEC11CD /* Foundation.framework */; };
@@ -385,6 +386,7 @@
 		B98BEE20D4ADA7BAE7226CB4669088B5 /* Builder-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "Builder-dummy.m"; sourceTree = "<group>"; };
 		BAE263041362D074978BB3B577DF0A05 /* Nimble */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; name = Nimble; path = Nimble.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		BB8DF63927B1294500CC78BC /* PlannedLayoutScheme.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlannedLayoutScheme.swift; sourceTree = "<group>"; };
+		BB8DF63B27B1593E00CC78BC /* ViewScheme.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ViewScheme.swift; sourceTree = "<group>"; };
 		BD06FE6BA5E4955C3F40CEE9D13ADE2C /* FragmentCell.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = FragmentCell.swift; sourceTree = "<group>"; };
 		BE45FDE30054808E0F6ABE006F76E50D /* NMBExceptionCapture.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = NMBExceptionCapture.m; path = Sources/NimbleObjectiveC/NMBExceptionCapture.m; sourceTree = "<group>"; };
 		BF229AEEB0F1D4292FF6F14A44B60EC9 /* QuickSpecBase.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = QuickSpecBase.m; path = Sources/QuickObjCRuntime/QuickSpecBase.m; sourceTree = "<group>"; };
@@ -623,6 +625,7 @@
 				7234D172C56D017190329F457D41B3F0 /* ViewScheme+Dimension.swift */,
 				72EC3DA616BAFB9D2874A5845E57ED6B /* ViewScheme+Shortcuts.swift */,
 				BB8DF63927B1294500CC78BC /* PlannedLayoutScheme.swift */,
+				BB8DF63B27B1593E00CC78BC /* ViewScheme.swift */,
 			);
 			name = Plan;
 			path = Draftsman/Classes/Plan;
@@ -1234,6 +1237,7 @@
 				977B971036EF83A127E6134ED6296817 /* PriorityConvertible.swift in Sources */,
 				AF0B3A29CFB2B1E5209829147087231F /* RootViewPlan.swift in Sources */,
 				2C7A04990D3ADC0CD9546F515B720640 /* SchemeCollection.swift in Sources */,
+				BB8DF63C27B1593E00CC78BC /* ViewScheme.swift in Sources */,
 				8D09E6948F69B22A1A249F18BEEFEE6D /* UIView+Draftsman.swift in Sources */,
 				C25CBF877B744E2E8CFA1D935F823BB9 /* ViewScheme+Axis.swift in Sources */,
 				7EC15925AA1D577AA23290FECC05F1C5 /* ViewScheme+Dimension.swift in Sources */,

--- a/Example/Tests/EdgesConstraintsSpec.swift
+++ b/Example/Tests/EdgesConstraintsSpec.swift
@@ -101,7 +101,7 @@ class EdgesConstraintsSpec: QuickSpec {
                 var context: PlanContext!
                 var plan: LayoutScheme<UIView>!
                 beforeEach {
-                    context = PlanContext(currentView: otherView)
+                    context = PlanContext(delegate: nil, rootContextView: otherView, usingViewPlan: false)
                     context.currentView = view
                     plan = view.plan
                     plan.context = context

--- a/Example/Tests/PlanContextSpec.swift
+++ b/Example/Tests/PlanContextSpec.swift
@@ -18,7 +18,7 @@ class PlanContextSpec: QuickSpec {
         describe("plan context") {
             var context: PlanContext!
             beforeEach {
-                context = .init(currentView: UIView())
+                context = PlanContext(delegate: nil, rootContextView: UIView(), usingViewPlan: false)
             }
             it("should mutating priority") {
                 let currentPriority = context.currentPriority.rawValue

--- a/Package.resolved
+++ b/Package.resolved
@@ -33,8 +33,8 @@
         "repositoryURL": "https://github.com/mattgallagher/CwlPreconditionTesting.git",
         "state": {
           "branch": null,
-          "revision": "02b7a39a99c4da27abe03cab2053a9034379639f",
-          "version": "2.0.0"
+          "revision": "c21f7bab5ca8eee0a9998bbd17ca1d0eb45d4688",
+          "version": "2.1.0"
         }
       },
       {
@@ -42,8 +42,8 @@
         "repositoryURL": "https://github.com/Quick/Nimble.git",
         "state": {
           "branch": null,
-          "revision": "af1730dde4e6c0d45bf01b99f8a41713ce536790",
-          "version": "9.2.0"
+          "revision": "c93f16c25af5770f0d3e6af27c9634640946b068",
+          "version": "9.2.1"
         }
       },
       {

--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.3
+// swift-tools-version:5.5
 // The swift-tools-version declares the minimum version of Swift required to build this package.
 
 import PackageDescription
@@ -6,7 +6,7 @@ import PackageDescription
 let package = Package(
     name: "Draftsman",
     platforms: [
-        .iOS(.v11)
+        .iOS(.v12)
     ],
     products: [
         .library(

--- a/Package.swift
+++ b/Package.swift
@@ -18,7 +18,7 @@ let package = Package(
         .package(url: "https://github.com/hainayanda/Clavier.git", from: "1.0.3"),
         .package(url: "https://github.com/hainayanda/Builder.git", from: "1.0.3"),
         .package(url: "https://github.com/Quick/Quick.git", from: "4.0.0"),
-        .package(url: "https://github.com/Quick/Nimble.git", from: "9.2.0")
+        .package(url: "https://github.com/Quick/Nimble.git", from: "9.2.1")
     ],
     targets: [
         .target(


### PR DESCRIPTION
- Ignore any Planned component (Fragment included) if it's already planned, thus improving rendering speed when the view contains many fragments that have already been applied
- Will throw fatalError if any Planned component try to insert child view that is Planned component (Fragment included)
- Refactor protocol and class hierarchy to hide some unnecessary public implementation
- Update platform to iOS 12
- Update swift to swift 5
- Remove deprecated code